### PR TITLE
cron: fix phonebookjs restart time

### DIFF
--- a/root/etc/cron.d/phonebook
+++ b/root/etc/cron.d/phonebook
@@ -2,5 +2,5 @@
 0  0  *  *  *  root  /usr/share/phonebooks/phonebook &> /dev/null
 
 # Refresh phonebookjs every hour
-*  0  *  *  *  root /usr/bin/systemctl try-restart phonebookjs &> /dev/null
+0  *  *  *  *  root /usr/bin/systemctl try-restart phonebookjs &> /dev/null
 


### PR DESCRIPTION
phonebookjs should be restarted once an hour, not every minute after midnight 