### PR TITLE
Don't fail if any name in phonebook contains ";"

### DIFF
--- a/root/usr/share/phonebookjs/phonebook.js
+++ b/root/usr/share/phonebookjs/phonebook.js
@@ -124,8 +124,8 @@ db.query("SELECT name,company,homephone,workphone,cellphone,fax FROM phonebook",
         }
     }
     // replace invalid chars in dn
-    name = name.replace(/#|%|,|\+|\"|\\|\>|\<|\;|=|\/|{|}|\||\^|~|\r|\n|`|\*/g,' ');
-    name = name.replace(/^ *| *$/g,'');
+    name = name.replace(/,|\+|\"|\\|\>|\<|\;|\r|\n|=|\//g,' ');
+    name = name.replace(/^[# ]*|[# ]*$/g,'');
     name = name.toLowerCase();
 
     var cn = "cn=" + name + ", " + config.basedn;


### PR DESCRIPTION
If a contact contains the `;` char, the server fails to start.

We need to take care also of others chars, see https://docs.microsoft.com/en-us/previous-versions/windows/desktop/ldap/distinguished-names

The problem should affect also non-TLS server instance.

https://github.com/nethesis/dev/issues/5837