### PR TITLE
Fix config restore on a clean system

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -60,7 +60,6 @@ event_services($event, qw(
 #
 event_actions('post-restore-config', qw(
     nethserver-phonebook-mysql-fixldap 19
-    nethserver-phonebook-mysql-conf 60
 ));
 
 #


### PR DESCRIPTION
The action /etc/e-smith/events/post-restore-config/S50nethserver-mysql-restore-config
does not expand /root/.my.cnf. We must wait the nethserver-mysql-update event completion
before running our initialization/upgrade script.

Binding actions to the post-restore-config event is harmful.

nethesis/dev#5935