### PR TITLE
config: expand config_ldaps.json on certificate-update

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -68,6 +68,7 @@ event_actions('post-restore-config', qw(
 $event = "certificate-update";
 
 templates2events ('/etc/phonebookjs/fullchain.pem',$event);
+templates2events ('/usr/share/phonebookjs/config_ldaps.json',$event);
 
 event_services($event, qw(
     phonebookjss restart


### PR DESCRIPTION
Otherwise the key path is not updated and the service will try to run
with a certificate that doesn't match the private key

Nethesis/dev#5949