### PR TITLE
Sometimes auto dialect detect fails

### DIFF
--- a/root/usr/share/phonebooks/phonebook-import
+++ b/root/usr/share/phonebooks/phonebook-import
@@ -161,7 +161,7 @@ def syncSourceCsv(path, output, deleteonly):
   b_obj.seek(0)
 
   df = []
-  sample = b_obj.read(1024)
+  sample = b_obj.readline()
   b_obj.seek(0)
   dialect = csv.Sniffer().sniff(sample)
   if (not csv.Sniffer().has_header(sample)):


### PR DESCRIPTION
With some particular input auto dialect detect may fail, because actually it passes the firs 1024 byte of the file instead of the first line.
https://stackoverflow.com/questions/35756682/getting-csv-sniffer-to-work-with-quoted-values
With this modify only the first line of the file is readed.