### PR TITLE
db: fix pbookuser user's password on update event 

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-phonebook-mysql-conf
+++ b/root/etc/e-smith/events/actions/nethserver-phonebook-mysql-conf
@@ -77,4 +77,8 @@ else
         echo "[NOTICE] Adding sid_imported field"
         mysql --defaults-file=/root/.my.cnf phonebook -e "ALTER TABLE phonebook ADD sid_imported varchar(255) default NULL"
     fi
+
+    #Set the pbookuser user's password, in the case that was updated.
+    /usr/bin/mysql --defaults-file=/root/.my.cnf -e "SET PASSWORD FOR 'pbookuser'@'%' = PASSWORD('$db_pwd')"
+    /usr/bin/mysql --defaults-file=/root/.my.cnf -e 'FLUSH PRIVILEGES'
 fi


### PR DESCRIPTION
Make sure that the MySQL `pbookuser` user's password is kept in sync with the `PhonebookDBPasswd` NethServer secret.

Also, remove unused sogo user.

nethesis/dev#6054