### PR TITLE
Add custom phonebook sources to backup config

### DIFF
--- a/root/etc/backup-config.d/nethserver-phonebook.include
+++ b/root/etc/backup-config.d/nethserver-phonebook.include
@@ -1,1 +1,2 @@
 /usr/share/phonebooks/scripts/
+/etc/phonebook/sources.d/


### PR DESCRIPTION
Custom phonebook sources are defined in json files inside /etc/phonebook/sources.d/ and this directory wasn't included into backup-config
https://github.com/nethesis/dev/issues/6084